### PR TITLE
feat: support sync & async load_filtered_policy

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
 PyMongo Adapter for PyCasbin
 ====
 
-[![Build Status](https://www.travis-ci.org/officialpycasbin/pymongo-adapter.svg?branch=master)](https://www.travis-ci.org/officialpycasbin/pymongo-adapter)
+[![build Status](https://github.com/officialpycasbin/pymongo-adapter/actions/workflows/main.yml/badge.svg)](https://github.com/officialpycasbin/pymongo-adapter/actions/workflows/main.yml)
 [![Coverage Status](https://coveralls.io/repos/github/officialpycasbin/pymongo-adapter/badge.svg)](https://coveralls.io/github/officialpycasbin/pymongo-adapter)
 [![Version](https://img.shields.io/pypi/v/casbin_pymongo_adapter.svg)](https://pypi.org/project/casbin_pymongo_adapter/)
 [![PyPI - Wheel](https://img.shields.io/pypi/wheel/casbin_pymongo_adapter.svg)](https://pypi.org/project/casbin_pymongo_adapter/)
 [![Pyversions](https://img.shields.io/pypi/pyversions/casbin_pymongo_adapter.svg)](https://pypi.org/project/casbin_pymongo_adapter/)
-[![Download](https://img.shields.io/pypi/dm/casbin_pymongo_adapter.svg)](https://pypi.org/project/casbin_pymongo_adapter/)
+[![Download](https://static.pepy.tech/badge/casbin_pymongo_adapter)](https://pypi.org/project/casbin_pymongo_adapter/)
 [![License](https://img.shields.io/pypi/l/casbin_pymongo_adapter.svg)](https://pypi.org/project/casbin_pymongo_adapter/)
 
 PyMongo Adapter is the [PyMongo](https://pypi.org/project/pymongo/) adapter for [PyCasbin](https://github.com/casbin/pycasbin). With this library, Casbin can load policy from MongoDB or save policy to it.

--- a/README.md
+++ b/README.md
@@ -11,6 +11,8 @@ PyMongo Adapter for PyCasbin
 
 PyMongo Adapter is the [PyMongo](https://pypi.org/project/pymongo/) adapter for [PyCasbin](https://github.com/casbin/pycasbin). With this library, Casbin can load policy from MongoDB or save policy to it.
 
+This adapter supports both synchronous and asynchronous PyMongo APIs.
+
 ## Installation
 
 ```
@@ -37,6 +39,38 @@ if e.enforce(sub, obj, act):
 else:
     # deny the request, show an error
     pass
+
+# define filter conditions
+from casbin_pymongo_adapter import Filter
+
+filter = Filter()
+filter.ptype = ["p"]
+filter.v0 = ["alice"]
+
+# support MongoDB native query
+filter.raw_query = {
+    "ptype": "p",
+    "v0": {
+        "$in": ["alice"]
+    }
+}
+
+# In this case, load only policies with sub value alice
+e.load_filtered_policy(filter)
+```
+
+## Async Example
+
+```python
+from casbin_pymongo_adapter.asynchronous import Adapter
+import casbin
+
+adapter = Adapter('mongodb://localhost:27017/', "dbname")
+e = casbin.AsyncEnforcer('path/to/model.conf', adapter)
+
+# Note: AsyncEnforcer does not automatically load policies.
+# You need to call load_policy() manually.
+await e.load_policy()
 ```
 
 

--- a/casbin_pymongo_adapter/__init__.py
+++ b/casbin_pymongo_adapter/__init__.py
@@ -1,1 +1,9 @@
 from .adapter import Adapter
+from ._filter import Filter
+from ._rule import CasbinRule
+
+__all__ = [
+    "Adapter",
+    "Filter",
+    "CasbinRule",
+]

--- a/casbin_pymongo_adapter/_filter.py
+++ b/casbin_pymongo_adapter/_filter.py
@@ -1,0 +1,16 @@
+class Filter:
+    """
+    Filter rule model
+    """
+
+    ptype = []
+    v0 = []
+    v1 = []
+    v2 = []
+    v3 = []
+    v4 = []
+    v5 = []
+
+    # `raw_query` expected dict.
+    # if set `raw_query`, all other filters are ignored
+    raw_query = None

--- a/casbin_pymongo_adapter/asynchronous/__init__.py
+++ b/casbin_pymongo_adapter/asynchronous/__init__.py
@@ -1,0 +1,5 @@
+from .adapter import Adapter
+
+__all__ = [
+    "Adapter",
+]

--- a/tests/asynchronous/test_adapter.py
+++ b/tests/asynchronous/test_adapter.py
@@ -1,6 +1,5 @@
-from casbin_pymongo_adapter._filter import Filter
-from casbin_pymongo_adapter.asynchronous.adapter import Adapter
-from casbin_pymongo_adapter._rule import CasbinRule
+from casbin_pymongo_adapter.asynchronous import Adapter
+from casbin_pymongo_adapter import Filter
 from pymongo import AsyncMongoClient
 from unittest import IsolatedAsyncioTestCase
 import casbin

--- a/tests/asynchronous/test_adapter.py
+++ b/tests/asynchronous/test_adapter.py
@@ -197,22 +197,6 @@ class TestConfig(IsolatedAsyncioTestCase):
         self.assertFalse(e.enforce("alice", "data2", "read"))
         self.assertFalse(e.enforce("alice", "data2", "write"))
 
-    def test_str(self):
-        """
-        test __str__ function
-        """
-        rule = CasbinRule(ptype="p", v0="alice", v1="data1", v2="read")
-        self.assertEqual(rule.__str__(), "p, alice, data1, read")
-
-    def test_dict(self):
-        """
-        test __str__ function
-        """
-        rule = CasbinRule(ptype="p", v0="alice", v1="data1", v2="read")
-        self.assertEqual(
-            rule.dict(), {"ptype": "p", "v0": "alice", "v1": "data1", "v2": "read"}
-        )
-
     async def test_filtered_policy(self):
         """
         test filtered_policy

--- a/tests/test_adapter.py
+++ b/tests/test_adapter.py
@@ -1,3 +1,4 @@
+from casbin_pymongo_adapter._filter import Filter
 from casbin_pymongo_adapter.adapter import Adapter
 from casbin_pymongo_adapter._rule import CasbinRule
 from pymongo import MongoClient
@@ -199,6 +200,149 @@ class TestConfig(TestCase):
         self.assertTrue(e.enforce("bob", "data2", "write"))
         self.assertFalse(e.enforce("alice", "data2", "read"))
         self.assertFalse(e.enforce("alice", "data2", "write"))
+
+    async def test_filtered_policy(self):
+        """
+        test filtered_policy
+        """
+        e = get_enforcer()
+        filter = Filter()
+
+        filter.ptype = ["p"]
+        e.load_filtered_policy(filter)
+        self.assertTrue(e.enforce("alice", "data1", "read"))
+        self.assertFalse(e.enforce("alice", "data1", "write"))
+        self.assertFalse(e.enforce("alice", "data2", "read"))
+        self.assertFalse(e.enforce("alice", "data2", "write"))
+        self.assertFalse(e.enforce("bob", "data1", "read"))
+        self.assertFalse(e.enforce("bob", "data1", "write"))
+        self.assertFalse(e.enforce("bob", "data2", "read"))
+        self.assertTrue(e.enforce("bob", "data2", "write"))
+
+        filter.ptype = []
+        filter.v0 = ["alice"]
+        e.load_filtered_policy(filter)
+        self.assertTrue(e.enforce("alice", "data1", "read"))
+        self.assertFalse(e.enforce("alice", "data1", "write"))
+        self.assertFalse(e.enforce("alice", "data2", "read"))
+        self.assertFalse(e.enforce("alice", "data2", "write"))
+        self.assertFalse(e.enforce("bob", "data1", "read"))
+        self.assertFalse(e.enforce("bob", "data1", "write"))
+        self.assertFalse(e.enforce("bob", "data2", "read"))
+        self.assertFalse(e.enforce("bob", "data2", "write"))
+        self.assertFalse(e.enforce("data2_admin", "data2", "read"))
+        self.assertFalse(e.enforce("data2_admin", "data2", "write"))
+
+        filter.v0 = ["bob"]
+        e.load_filtered_policy(filter)
+        self.assertFalse(e.enforce("alice", "data1", "read"))
+        self.assertFalse(e.enforce("alice", "data1", "write"))
+        self.assertFalse(e.enforce("alice", "data2", "read"))
+        self.assertFalse(e.enforce("alice", "data2", "write"))
+        self.assertFalse(e.enforce("bob", "data1", "read"))
+        self.assertFalse(e.enforce("bob", "data1", "write"))
+        self.assertFalse(e.enforce("bob", "data2", "read"))
+        self.assertTrue(e.enforce("bob", "data2", "write"))
+        self.assertFalse(e.enforce("data2_admin", "data2", "read"))
+        self.assertFalse(e.enforce("data2_admin", "data2", "write"))
+
+        filter.v0 = ["data2_admin"]
+        e.load_filtered_policy(filter)
+        self.assertTrue(e.enforce("data2_admin", "data2", "read"))
+        self.assertTrue(e.enforce("data2_admin", "data2", "read"))
+        self.assertFalse(e.enforce("alice", "data1", "read"))
+        self.assertFalse(e.enforce("alice", "data1", "write"))
+        self.assertFalse(e.enforce("alice", "data2", "read"))
+        self.assertFalse(e.enforce("alice", "data2", "write"))
+        self.assertFalse(e.enforce("bob", "data1", "read"))
+        self.assertFalse(e.enforce("bob", "data1", "write"))
+        self.assertFalse(e.enforce("bob", "data2", "read"))
+        self.assertFalse(e.enforce("bob", "data2", "write"))
+
+        filter.v0 = ["alice", "bob"]
+        e.load_filtered_policy(filter)
+        self.assertTrue(e.enforce("alice", "data1", "read"))
+        self.assertFalse(e.enforce("alice", "data1", "write"))
+        self.assertFalse(e.enforce("alice", "data2", "read"))
+        self.assertFalse(e.enforce("alice", "data2", "write"))
+        self.assertFalse(e.enforce("bob", "data1", "read"))
+        self.assertFalse(e.enforce("bob", "data1", "write"))
+        self.assertFalse(e.enforce("bob", "data2", "read"))
+        self.assertTrue(e.enforce("bob", "data2", "write"))
+        self.assertFalse(e.enforce("data2_admin", "data2", "read"))
+        self.assertFalse(e.enforce("data2_admin", "data2", "write"))
+
+        filter.v0 = []
+        filter.v1 = ["data1"]
+        e.load_filtered_policy(filter)
+        self.assertTrue(e.enforce("alice", "data1", "read"))
+        self.assertFalse(e.enforce("alice", "data1", "write"))
+        self.assertFalse(e.enforce("alice", "data2", "read"))
+        self.assertFalse(e.enforce("alice", "data2", "write"))
+        self.assertFalse(e.enforce("bob", "data1", "read"))
+        self.assertFalse(e.enforce("bob", "data1", "write"))
+        self.assertFalse(e.enforce("bob", "data2", "read"))
+        self.assertFalse(e.enforce("bob", "data2", "write"))
+        self.assertFalse(e.enforce("data2_admin", "data2", "read"))
+        self.assertFalse(e.enforce("data2_admin", "data2", "write"))
+
+        filter.v1 = ["data2"]
+        e.load_filtered_policy(filter)
+        self.assertFalse(e.enforce("alice", "data1", "read"))
+        self.assertFalse(e.enforce("alice", "data1", "write"))
+        self.assertFalse(e.enforce("alice", "data2", "read"))
+        self.assertFalse(e.enforce("alice", "data2", "write"))
+        self.assertFalse(e.enforce("bob", "data1", "read"))
+        self.assertFalse(e.enforce("bob", "data1", "write"))
+        self.assertFalse(e.enforce("bob", "data2", "read"))
+        self.assertTrue(e.enforce("bob", "data2", "write"))
+        self.assertTrue(e.enforce("data2_admin", "data2", "read"))
+        self.assertTrue(e.enforce("data2_admin", "data2", "write"))
+
+        filter.v1 = []
+        filter.v2 = ["read"]
+        e.load_filtered_policy(filter)
+        self.assertTrue(e.enforce("alice", "data1", "read"))
+        self.assertFalse(e.enforce("alice", "data1", "write"))
+        self.assertFalse(e.enforce("alice", "data2", "read"))
+        self.assertFalse(e.enforce("alice", "data2", "write"))
+        self.assertFalse(e.enforce("bob", "data1", "read"))
+        self.assertFalse(e.enforce("bob", "data1", "write"))
+        self.assertFalse(e.enforce("bob", "data2", "read"))
+        self.assertFalse(e.enforce("bob", "data2", "write"))
+        self.assertTrue(e.enforce("data2_admin", "data2", "read"))
+        self.assertFalse(e.enforce("data2_admin", "data2", "write"))
+
+        filter.v2 = ["write"]
+        e.load_filtered_policy(filter)
+        self.assertFalse(e.enforce("alice", "data1", "read"))
+        self.assertFalse(e.enforce("alice", "data1", "write"))
+        self.assertFalse(e.enforce("alice", "data2", "read"))
+        self.assertFalse(e.enforce("alice", "data2", "write"))
+        self.assertFalse(e.enforce("bob", "data1", "read"))
+        self.assertFalse(e.enforce("bob", "data1", "write"))
+        self.assertFalse(e.enforce("bob", "data2", "read"))
+        self.assertTrue(e.enforce("bob", "data2", "write"))
+        self.assertFalse(e.enforce("data2_admin", "data2", "read"))
+        self.assertTrue(e.enforce("data2_admin", "data2", "write"))
+
+    async def test_filtered_policy_with_raw_query(self):
+        """
+        test filtered_policy
+        """
+        e = get_enforcer()
+        filter = Filter()
+        filter.raw_query = {"ptype": "p", "v0": {"$in": ["alice", "bob"]}}
+
+        e.load_filtered_policy(filter)
+        self.assertTrue(e.enforce("alice", "data1", "read"))
+        self.assertFalse(e.enforce("alice", "data1", "write"))
+        self.assertFalse(e.enforce("alice", "data2", "read"))
+        self.assertFalse(e.enforce("alice", "data2", "write"))
+        self.assertFalse(e.enforce("bob", "data1", "read"))
+        self.assertFalse(e.enforce("bob", "data1", "write"))
+        self.assertFalse(e.enforce("bob", "data2", "read"))
+        self.assertTrue(e.enforce("bob", "data2", "write"))
 
     def test_str(self):
         """

--- a/tests/test_adapter.py
+++ b/tests/test_adapter.py
@@ -1,6 +1,5 @@
-from casbin_pymongo_adapter._filter import Filter
-from casbin_pymongo_adapter.adapter import Adapter
 from casbin_pymongo_adapter._rule import CasbinRule
+from casbin_pymongo_adapter import Filter, Adapter
 from pymongo import MongoClient
 from unittest import TestCase
 import casbin


### PR DESCRIPTION
Fix: https://github.com/officialpycasbin/pymongo-adapter/issues/4

## Summary

- Added filtered policy loading support to PyMongo adapters (sync & async)
- Introduced Filter class for attribute-based and raw MongoDB query filters
- Implemented load_filtered_policy / is_filtered methods to manage filter state
- Updated README with usage examples for both sync and async adapters
- Added tests for filtered loading and raw query support in sync/async test suites
- Exposed Filter in __init__.py and cleaned up test imports
