### PR TITLE
feat: support sync & async update_policy / update_policies

### DIFF
--- a/casbin_pymongo_adapter/adapter.py
+++ b/casbin_pymongo_adapter/adapter.py
@@ -175,3 +175,23 @@ class Adapter(persist.Adapter):
         query["ptype"] = ptype
         results = self._collection.delete_many(query)
         return results.deleted_count > 0
+
+    def update_policy(self, sec, ptype, old_rule, new_rule):
+        """Update the old_rule with the new_rule in the database (storage).
+
+        Args:
+            sec (str): section type
+            ptype (str): policy type
+            old_rule (list[str]): the old rule that needs to be modified
+            new_rule (list[str]): the new rule to replace the old rule
+        """
+        filter_query = {}
+        for index, value in enumerate(old_rule):
+            filter_query[f"v{index}"] = value
+
+        self._collection.find_one_and_update(
+            filter_query,
+            {"$set": {f"v{index}": value for index, value in enumerate(new_rule)}},
+        )
+
+        return None

--- a/casbin_pymongo_adapter/adapter.py
+++ b/casbin_pymongo_adapter/adapter.py
@@ -195,3 +195,15 @@ class Adapter(persist.Adapter):
         )
 
         return None
+
+    def update_policies(self, sec, ptype, old_rules, new_rules):
+        """Update the old_rule with the new_rule in the database (storage).
+
+        Args:
+            sec (str): section type
+            ptype (str): policy type
+            old_rules (list[list[str]]): the old rules that needs to be modified
+            new_rules (list[list[str]]): the new rules to replace the old rule
+        """
+        for old_rule, new_rule in zip(old_rules, new_rules):
+            self.update_policy(sec, ptype, old_rule, new_rule)

--- a/casbin_pymongo_adapter/asynchronous/adapter.py
+++ b/casbin_pymongo_adapter/asynchronous/adapter.py
@@ -169,3 +169,23 @@ class Adapter(AsyncAdapter):
         query["ptype"] = ptype
         results = await self._collection.delete_many(query)
         return results.deleted_count > 0
+
+    async def update_policy(self, sec, ptype, old_rule, new_rule):
+        """Update the old_rule with the new_rule in the database (storage).
+
+        Args:
+            sec (str): section type
+            ptype (str): policy type
+            old_rule (list[str]): the old rule that needs to be modified
+            new_rule (list[str]): the new rule to replace the old rule
+        """
+        filter_query = {}
+        for index, value in enumerate(old_rule):
+            filter_query[f"v{index}"] = value
+
+        await self._collection.find_one_and_update(
+            filter_query,
+            {"$set": {f"v{index}": value for index, value in enumerate(new_rule)}},
+        )
+
+        return None

--- a/casbin_pymongo_adapter/asynchronous/adapter.py
+++ b/casbin_pymongo_adapter/asynchronous/adapter.py
@@ -189,3 +189,15 @@ class Adapter(AsyncAdapter):
         )
 
         return None
+
+    async def update_policies(self, sec, ptype, old_rules, new_rules):
+        """Update the old_rule with the new_rule in the database (storage).
+
+        Args:
+            sec (str): section type
+            ptype (str): policy type
+            old_rules (list[list[str]]): the old rules that needs to be modified
+            new_rules (list[list[str]]): the new rules to replace the old rule
+        """
+        for old_rule, new_rule in zip(old_rules, new_rules):
+            await self.update_policy(sec, ptype, old_rule, new_rule)

--- a/tests/asynchronous/test_adapter.py
+++ b/tests/asynchronous/test_adapter.py
@@ -367,3 +367,33 @@ class TestConfig(IsolatedAsyncioTestCase):
         self.assertTrue(e.enforce("carl", "data2", "write"))
         await e.update_policy(["carl", "data2", "write"], ["carl", "data2", "no_write"])
         self.assertFalse(e.enforce("bob", "data2", "write"))
+
+    async def test_update_policies(self):
+        e = await get_enforcer()
+
+        old_rule_0 = ["alice", "data1", "read"]
+        old_rule_1 = ["bob", "data2", "write"]
+        old_rule_2 = ["data2_admin", "data2", "read"]
+        old_rule_3 = ["data2_admin", "data2", "write"]
+
+        new_rule_0 = ["alice", "data_test", "read"]
+        new_rule_1 = ["bob", "data_test", "write"]
+        new_rule_2 = ["data2_admin", "data_test", "read"]
+        new_rule_3 = ["data2_admin", "data_test", "write"]
+
+        old_rules = [old_rule_0, old_rule_1, old_rule_2, old_rule_3]
+        new_rules = [new_rule_0, new_rule_1, new_rule_2, new_rule_3]
+
+        await e.update_policies(old_rules, new_rules)
+
+        self.assertFalse(e.enforce("alice", "data1", "read"))
+        self.assertTrue(e.enforce("alice", "data_test", "read"))
+
+        self.assertFalse(e.enforce("bob", "data2", "write"))
+        self.assertTrue(e.enforce("bob", "data_test", "write"))
+
+        self.assertFalse(e.enforce("data2_admin", "data2", "read"))
+        self.assertTrue(e.enforce("data2_admin", "data_test", "read"))
+
+        self.assertFalse(e.enforce("data2_admin", "data2", "write"))
+        self.assertTrue(e.enforce("data2_admin", "data_test", "write"))

--- a/tests/test_adapter.py
+++ b/tests/test_adapter.py
@@ -372,6 +372,36 @@ class TestConfig(TestCase):
         e.update_policy(["carl", "data2", "write"], ["carl", "data2", "no_write"])
         self.assertFalse(e.enforce("bob", "data2", "write"))
 
+    async def test_update_policies(self):
+        e = get_enforcer()
+
+        old_rule_0 = ["alice", "data1", "read"]
+        old_rule_1 = ["bob", "data2", "write"]
+        old_rule_2 = ["data2_admin", "data2", "read"]
+        old_rule_3 = ["data2_admin", "data2", "write"]
+
+        new_rule_0 = ["alice", "data_test", "read"]
+        new_rule_1 = ["bob", "data_test", "write"]
+        new_rule_2 = ["data2_admin", "data_test", "read"]
+        new_rule_3 = ["data2_admin", "data_test", "write"]
+
+        old_rules = [old_rule_0, old_rule_1, old_rule_2, old_rule_3]
+        new_rules = [new_rule_0, new_rule_1, new_rule_2, new_rule_3]
+
+        e.update_policies(old_rules, new_rules)
+
+        self.assertFalse(e.enforce("alice", "data1", "read"))
+        self.assertTrue(e.enforce("alice", "data_test", "read"))
+
+        self.assertFalse(e.enforce("bob", "data2", "write"))
+        self.assertTrue(e.enforce("bob", "data_test", "write"))
+
+        self.assertFalse(e.enforce("data2_admin", "data2", "read"))
+        self.assertTrue(e.enforce("data2_admin", "data_test", "read"))
+
+        self.assertFalse(e.enforce("data2_admin", "data2", "write"))
+        self.assertTrue(e.enforce("data2_admin", "data_test", "write"))
+
     def test_str(self):
         """
         test __str__ function

--- a/tests/test_adapter.py
+++ b/tests/test_adapter.py
@@ -343,6 +343,35 @@ class TestConfig(TestCase):
         self.assertFalse(e.enforce("bob", "data2", "read"))
         self.assertTrue(e.enforce("bob", "data2", "write"))
 
+    async def test_update_policy(self):
+        e = get_enforcer()
+        example_p = ["mike", "cookie", "eat"]
+
+        self.assertTrue(e.enforce("alice", "data1", "read"))
+        e.update_policy(["alice", "data1", "read"], ["alice", "data1", "no_read"])
+        self.assertFalse(e.enforce("alice", "data1", "read"))
+
+        self.assertFalse(e.enforce("bob", "data1", "read"))
+        e.add_policy(example_p)
+        e.update_policy(example_p, ["bob", "data1", "read"])
+        self.assertTrue(e.enforce("bob", "data1", "read"))
+
+        self.assertFalse(e.enforce("bob", "data1", "write"))
+        e.update_policy(["bob", "data1", "read"], ["bob", "data1", "write"])
+        self.assertTrue(e.enforce("bob", "data1", "write"))
+
+        self.assertTrue(e.enforce("bob", "data2", "write"))
+        e.update_policy(["bob", "data2", "write"], ["bob", "data2", "read"])
+        self.assertFalse(e.enforce("bob", "data2", "write"))
+
+        self.assertTrue(e.enforce("bob", "data2", "read"))
+        e.update_policy(["bob", "data2", "read"], ["carl", "data2", "write"])
+        self.assertFalse(e.enforce("bob", "data2", "write"))
+
+        self.assertTrue(e.enforce("carl", "data2", "write"))
+        e.update_policy(["carl", "data2", "write"], ["carl", "data2", "no_write"])
+        self.assertFalse(e.enforce("bob", "data2", "write"))
+
     def test_str(self):
         """
         test __str__ function


### PR DESCRIPTION
fix: #6 

## summary

- Added `update_policy` and `update_policies` methods to sync & async.
- The test cases are the same as those of [async-sqlalchemy-adapter](https://github.com/officialpycasbin/async-sqlalchemy-adapter).